### PR TITLE
Add log collection feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2768,6 +2768,7 @@ dependencies = [
  "jni-sys",
  "log",
  "log-panics",
+ "serde",
  "serde_json",
  "tokio 1.18.0",
  "uplink",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2770,6 +2770,7 @@ dependencies = [
  "log-panics",
  "serde",
  "serde_json",
+ "thiserror",
  "tokio 1.18.0",
  "uplink",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ log-panics = "2.0"
 serde_json = "1.0"
 serde = "1"
 tokio = { version = "1", features = ["full"] }
+thiserror = "1"
 uplink = { git = "https://github.com/bytebeamio/uplink" }
 
 [lib]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ jni-sys = "0.3"
 log = "0.4"
 log-panics = "2.0"
 serde_json = "1.0"
+serde = "1"
 tokio = { version = "1", features = ["full"] }
 uplink = { git = "https://github.com/bytebeamio/uplink" }
 

--- a/app/src/main/java/io/bytebeam/UplinkDemo/MainActivity.java
+++ b/app/src/main/java/io/bytebeam/UplinkDemo/MainActivity.java
@@ -114,7 +114,8 @@ public class MainActivity extends AppCompatActivity implements ActionCallback {
         try {
             ConfigBuilder config = new ConfigBuilder(base)
                     .setOta(true, baseFolder + "/ota-file")
-                    .setPersistence(baseFolder + "/uplink", 104857600, 3);
+                    .setPersistence(baseFolder + "/uplink", 104857600, 3)
+                    .enableLogCollector();
 
             uplink = new Uplink(config.build());
             uplink.subscribe(this);

--- a/lib/src/main/java/io/bytebeam/uplink/ConfigBuilder.java
+++ b/lib/src/main/java/io/bytebeam/uplink/ConfigBuilder.java
@@ -25,6 +25,11 @@ public class ConfigBuilder {
         return this;
     }
 
+    public ConfigBuilder enableLogCollector() {
+        config.enableLogCollector();
+        return this;
+    }
+
     public UplinkConfig build() {
         return config;
     }

--- a/src/action_handler.rs
+++ b/src/action_handler.rs
@@ -1,0 +1,89 @@
+use flume::{Receiver, Sender};
+use log::error;
+use uplink::{Action, ActionResponse, Package, Stream};
+
+use crate::{logcat::LogConfig, UplinkAction};
+
+pub trait ActionCallback {
+    fn recvd_action(&self, action: UplinkAction);
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum Error {
+    #[error("Error receiving Action: {0}")]
+    Recv(#[from] flume::RecvError),
+    #[error("Error forwarding Action: {0}")]
+    Send(#[from] flume::SendError<Action>),
+    #[error("Error extracting LogConfig: {0}")]
+    Json(#[from] serde_json::Error),
+}
+
+pub struct ActionHandler {
+    bridge_rx: Receiver<Action>,
+    actions_tx: Sender<Action>,
+    data_tx: Sender<Box<dyn Package>>,
+    action_status: Stream<ActionResponse>,
+    log_enabled: bool,
+}
+
+impl ActionHandler {
+    pub fn new(
+        bridge_rx: Receiver<Action>,
+        data_tx: Sender<Box<dyn Package>>,
+        action_status: Stream<ActionResponse>,
+        log_enabled: bool,
+    ) -> (Self, Receiver<Action>) {
+        let (actions_tx, actions_rx) = flume::bounded(10);
+        (
+            Self {
+                bridge_rx,
+                actions_tx,
+                data_tx,
+                action_status,
+                log_enabled,
+            },
+            actions_rx,
+        )
+    }
+
+    pub fn start(mut self) -> Result<(), Error> {
+        loop {
+            let action = self.bridge_rx.recv()?;
+            let id = action.action_id.to_owned();
+
+            if let Err(e) = self.select(action) {
+                let resp = ActionResponse::failure(&id, e.to_string());
+                self.action_status.push(resp).unwrap();
+            }
+        }
+    }
+
+    fn select(&self, action: Action) -> Result<(), Error> {
+        match action.kind.as_str() {
+            "log_collector" if self.log_enabled => {
+                let log_config = serde_json::from_str(&action.payload)?;
+                self.spawn_log_relay(log_config);
+            }
+            _ => {
+                self.actions_tx.send(action)?;
+            }
+        }
+
+        Ok(())
+    }
+
+    pub fn spawn_log_relay(&self, log_config: LogConfig) {
+        let log_stream = Stream::new(
+            &log_config.name,
+            &log_config.topic,
+            80,
+            self.data_tx.clone(),
+        );
+
+        std::thread::spawn(move || {
+            if let Err(e) = crate::logcat::relay_logs(log_stream, log_config) {
+                error!("Error while relaying logs: {}", e);
+            }
+        });
+    }
+}

--- a/src/java_glue.rs.in
+++ b/src/java_glue.rs.in
@@ -7,6 +7,7 @@ foreign_class!(class UplinkConfig {
     fn UplinkConfig::set_stats(&mut self, _: bool, _: u64); alias setStats;
     fn UplinkConfig::add_to_stats(&mut self, _: String); alias addToStats;
     fn UplinkConfig::set_persistence(&mut self, _: String, _: usize, _: usize); alias setPersistence;
+    fn UplinkConfig::enable_log_collector(&mut self); alias enableLogCollector;
 
     foreign_code r#"
     static {

--- a/src/logcat.rs
+++ b/src/logcat.rs
@@ -1,18 +1,31 @@
 use std::io::{BufRead, BufReader};
-use std::process::{Command, ExitStatus};
+use std::process::{Command, ExitStatus, Stdio};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
+use log::debug;
+use serde::{Deserialize, Serialize};
 use uplink::{Payload, Stream};
 
-#[derive(Debug, serde::Serialize)]
-enum LogLevel {
-    Debug,
-    Info,
-    Warning,
-    Error,
+#[derive(Debug, Deserialize)]
+pub struct LogConfig {
+    pub name: String,
+    pub topic: String,
+    pub tag: String,
+    pub min_level: LogLevel,
 }
 
-#[derive(Debug, serde::Serialize)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
+pub enum LogLevel {
+    Verbose = 0,
+    Debug = 1,
+    Info = 2,
+    Warn = 3,
+    Error = 4,
+    Assert = 5,
+    Fatal = 6,
+}
+
+#[derive(Debug, Serialize)]
 struct Log {
     level: LogLevel,
     tag: String,
@@ -20,17 +33,27 @@ struct Log {
 }
 
 impl Log {
-    fn from_string(log: String) -> Option<Self> {
+    fn from_string(log: String, config: &LogConfig) -> Option<Self> {
         let tokens: Vec<&str> = log.split(' ').collect();
 
-        let level = match tokens.get(4)? {
-            &"I" => LogLevel::Info,
-            &"D" => LogLevel::Debug,
-            &"W" => LogLevel::Warning,
-            &"E" => LogLevel::Error,
+        let level = match *(tokens.get(4)?) {
+            "F" => LogLevel::Fatal,
+            "A" => LogLevel::Assert,
+            "E" => LogLevel::Error,
+            "W" => LogLevel::Warn,
+            "I" => LogLevel::Info,
+            "D" => LogLevel::Debug,
+            _ => LogLevel::Verbose,
+        };
+
+        if level < config.min_level {
+            return None;
+        }
+
+        let tag = match tokens.get(5)? {
+            s if s == &config.tag => s.to_string(),
             _ => return None,
         };
-        let tag = tokens.get(5)?.to_string();
 
         Some(Self {
             level,
@@ -39,7 +62,7 @@ impl Log {
         })
     }
 
-    fn to_payload(self, sequence: u32) -> Result<Payload, String> {
+    fn to_payload(&self, sequence: u32) -> Result<Payload, String> {
         let payload = serde_json::to_value(self).map_err(|e| e.to_string())?;
         let timestamp = SystemTime::now()
             .duration_since(UNIX_EPOCH)
@@ -55,20 +78,29 @@ impl Log {
     }
 }
 
-pub fn relay_logs(mut log_stream: Stream<Payload>) -> Result<ExitStatus, String> {
+pub fn relay_logs(
+    mut log_stream: Stream<Payload>,
+    log_config: LogConfig,
+) -> Result<ExitStatus, String> {
     let mut logcat = Command::new("logcat")
         .args(["-v", "threadtime"])
+        .stdout(Stdio::piped())
         .spawn()
         .map_err(|e| e.to_string())?;
-    let stdout = logcat.stdout.as_mut().ok_or("stdout missing".to_string())?;
+    let stdout = logcat
+        .stdout
+        .as_mut()
+        .ok_or_else(|| "stdout missing".to_string())?;
     let stdout_reader = BufReader::new(stdout);
+
+    debug!("Collector setup to relay logs");
 
     for (sequence, line) in stdout_reader.lines().enumerate() {
         let log = line.map_err(|e| e.to_string())?;
-        let log = Log::from_string(log).ok_or("Log couldn't be parsed".to_string())?;
-        let data = log.to_payload(sequence as u32)?;
-
-        log_stream.push(data).map_err(|e| e.to_string())?;
+        if let Some(log) = Log::from_string(log, &log_config) {
+            let data = log.to_payload(sequence as u32)?;
+            log_stream.push(data).map_err(|e| e.to_string())?;
+        }
     }
 
     logcat.wait().map_err(|e| e.to_string())

--- a/src/logcat.rs
+++ b/src/logcat.rs
@@ -1,0 +1,53 @@
+use std::io::{BufRead, BufReader};
+use std::process::{Command, ExitStatus};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use uplink::{Payload, Stream};
+
+#[derive(Debug, serde::Serialize)]
+struct Log {
+    level: String,
+    msg: String,
+}
+
+impl Log {
+    fn from_string(msg: String) -> Self {
+        Self {
+            level: "".to_string(),
+            msg,
+        }
+    }
+
+    fn to_payload(self, sequence: u32) -> Result<Payload, String> {
+        let payload = serde_json::to_value(self).map_err(|e| e.to_string())?;
+        let timestamp = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or(Duration::from_secs(0))
+            .as_millis() as u64;
+
+        Ok(Payload {
+            stream: "logs".to_string(),
+            sequence,
+            timestamp,
+            payload,
+        })
+    }
+}
+
+pub fn relay_logs(mut log_stream: Stream<Payload>) -> Result<ExitStatus, String> {
+    let mut logcat = Command::new("logcat")
+        .args(["-v", "long"])
+        .spawn()
+        .map_err(|e| e.to_string())?;
+    let stdout = logcat.stdout.as_mut().ok_or("stdout missing".to_string())?;
+    let stdout_reader = BufReader::new(stdout);
+
+    for (sequence, line) in stdout_reader.lines().enumerate() {
+        let log = Log::from_string(line.map_err(|e| e.to_string())?);
+        let data = log.to_payload(sequence as u32)?;
+
+        log_stream.push(data).map_err(|e| e.to_string())?;
+    }
+
+    logcat.wait().map_err(|e| e.to_string())
+}


### PR DESCRIPTION
With the addition of this feature, users will be able to remotely start a logcat process and collect logs relevant to them. One can configure the log collector with a `"log_collector"` Action that contains following config details:
- `name`: Stream name
- `topic`: Stream's topic string
- `tag`: Logs with only this tag will be pushed to the topic
- `min_level`: Minimum level upto which logs shall be considered, else they will be dropped.